### PR TITLE
back feat: Support batch receive for consumer.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,10 +98,12 @@ export interface ConsumerConfig {
   batchIndexAckEnabled?: boolean;
   regexSubscriptionMode?: RegexSubscriptionMode;
   deadLetterPolicy?: DeadLetterPolicy;
+  batchReceivePolicy?: ConsumerBatchReceivePolicy;
 }
 
 export class Consumer {
   receive(timeout?: number): Promise<Message>;
+  batchReceive(): Promise<Message []>;
   acknowledge(message: Message): Promise<null>;
   acknowledgeId(messageId: MessageId): Promise<null>;
   negativeAcknowledge(message: Message): void;
@@ -179,6 +181,12 @@ export interface DeadLetterPolicy {
   deadLetterTopic: string;
   maxRedeliverCount?: number;
   initialSubscriptionName?: string;
+}
+
+export interface ConsumerBatchReceivePolicy {
+  maxNumMessages?: number;
+  maxNumBytes?: number;
+  timeoutMs?: number;
 }
 
 export class AuthenticationTls {

--- a/src/Consumer.h
+++ b/src/Consumer.h
@@ -44,6 +44,7 @@ class Consumer : public Napi::ObjectWrap<Consumer> {
   MessageListenerCallback *listener;
 
   Napi::Value Receive(const Napi::CallbackInfo &info);
+  Napi::Value BatchReceive(const Napi::CallbackInfo &info);
   Napi::Value Acknowledge(const Napi::CallbackInfo &info);
   Napi::Value AcknowledgeId(const Napi::CallbackInfo &info);
   void NegativeAcknowledge(const Napi::CallbackInfo &info);

--- a/src/ConsumerConfig.h
+++ b/src/ConsumerConfig.h
@@ -21,14 +21,17 @@
 #define CONSUMER_CONFIG_H
 
 #include <pulsar/c/consumer_configuration.h>
+#include "ThreadSafeDeferred.h"
 #include "MessageListener.h"
 
 #define MIN_ACK_TIMEOUT_MILLIS 10000
 
 class ConsumerConfig {
  public:
-  ConsumerConfig(const Napi::Object &consumerConfig, pulsar_message_listener messageListener);
+  ConsumerConfig();
   ~ConsumerConfig();
+  void InitConfig(const std::shared_ptr<ThreadSafeDeferred> deferred, const Napi::Object &consumerConfig,
+                  pulsar_message_listener messageListener);
   std::shared_ptr<pulsar_consumer_configuration_t> GetCConsumerConfig();
   std::string GetTopic();
   std::vector<std::string> GetTopics();

--- a/src/ThreadSafeDeferred.cc
+++ b/src/ThreadSafeDeferred.cc
@@ -96,3 +96,7 @@ void ThreadSafeDeferred::Reject(const std::string &errorMsg) {
   this->fate = EFate::REJECTED;
   this->tsf.Release();
 }
+
+bool ThreadSafeDeferred::IsDone() const {
+  return this->fate == EFate::RESOLVED || this->fate == EFate::REJECTED;
+}

--- a/src/ThreadSafeDeferred.h
+++ b/src/ThreadSafeDeferred.h
@@ -73,6 +73,7 @@ class ThreadSafeDeferred : public Napi::Promise::Deferred {
   inline void Reject() { this->Reject(""); }
   void Reject(
       const std::string &);  // <- if only Reject were virtual... But we can live without polymorphism here
+  bool IsDone() const;
 
   static std::shared_ptr<ThreadSafeDeferred> New(const Napi::Env env);
 };

--- a/tests/consumer.test.js
+++ b/tests/consumer.test.js
@@ -122,6 +122,37 @@ const Pulsar = require('../index');
           nAckRedeliverTimeoutMs: -12,
         })).rejects.toThrow('NAck timeout should be greater than or equal to zero');
       });
+
+      test('Ack timeout less 10000', async () => {
+        await expect(client.subscribe({
+          topic: 'test-topic',
+          subscription: 'sub1',
+          subscriptionType: 'Shared',
+          ackTimeoutMs: 100,
+        })).rejects.toThrow('Ack timeout should be 0 or greater than or equal to 10000');
+      });
+
+      test('NAck timeout less 0', async () => {
+        await expect(client.subscribe({
+          topic: 'test-topic',
+          subscription: 'sub1',
+          subscriptionType: 'Shared',
+          nAckRedeliverTimeoutMs: -1,
+        })).rejects.toThrow('NAck timeout should be greater than or equal to zero');
+      });
+
+      test('Batch Receive Config Error', async () => {
+        await expect(client.subscribe({
+          topic: 'test-batch-receive-policy-error',
+          subscription: 'sub1',
+          subscriptionType: 'Shared',
+          batchReceivePolicy: {
+            maxNumMessages: -1,
+            maxNumBytes: -1,
+            timeoutMs: -1,
+          },
+        })).rejects.toThrow('At least one of maxNumMessages, maxNumBytes and timeoutMs must be specified.');
+      });
     });
 
     describe('Close', () => {
@@ -314,6 +345,47 @@ const Pulsar = require('../index');
         producer.close();
         consumer.close();
         dlqConsumer.close();
+      });
+
+      test('Batch Receive', async () => {
+        const topicName = 'batch-receive-test-topic';
+        const producer = await client.createProducer({
+          topic: topicName,
+        });
+
+        const consumer = await client.subscribe({
+          topic: topicName,
+          subscription: 'sub1',
+          subscriptionType: 'Shared',
+          batchReceivePolicy: {
+            maxNumMessages: 10,
+            maxNumBytes: -1,
+            timeoutMs: 500,
+          },
+        });
+        const num = 10;
+        const messages = [];
+        for (let i = 0; i < num; i += 1) {
+          const msg = `my-message-${i}`;
+          await producer.send({ data: Buffer.from(msg) });
+          messages.push(msg);
+        }
+
+        const receiveMessages = await consumer.batchReceive();
+        expect(receiveMessages.length).toEqual(num);
+        const results = [];
+        for (let i = 0; i < receiveMessages.length; i += 1) {
+          const msg = receiveMessages[i];
+          console.log(msg.getData().toString());
+          results.push(msg.getData().toString());
+        }
+        expect(results).toEqual(messages);
+
+        // assert no more msgs.
+        expect(await consumer.batchReceive()).toEqual([]);
+
+        await producer.close();
+        await consumer.close();
       });
     });
   });


### PR DESCRIPTION
Master Issue: (todo 274)

### Motivation

(todo 274) Support batch receive for the consumer.


### Modifications

- Add batch receive policy config on the consumer.
- Add batch receive interface on the consumer.
- Refactor consumer `config set` and `verify logic`. 
  - Since config set logic with verify logic for the consumer is separate, it will be more complicated to read the code and subsequent extensions. 

### Verifying this change
- Add batch receive unit test on Consumer.
- Add more config verify unit test on Consumer.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc-required` 
(Your PR needs to update docs and you will update later)

- [ ] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
